### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/git_miner.py
+++ b/git_miner.py
@@ -9,6 +9,11 @@ import codecs
 os.system('cls' if os.name == 'nt' else 'clear')
 codecs.register(lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 class frescurinha:
     HELP = '\033[1;36m'
     OKBLUE = '\033[1;94m'


### PR DESCRIPTION
raw_input() was removed from Python 3 in favor of input().